### PR TITLE
Mirror of linkedin pinot#2806

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BasePartitionAwareRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BasePartitionAwareRoutingTableBuilder.java
@@ -61,9 +61,8 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
 
   protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
   protected SegmentZKMetadataPrunerService _pruner;
-  protected TableConfig _tableConfig;
   protected Random _random = new Random();
-  protected int _numReplicas;
+  protected volatile int _numReplicas;
 
   protected void setSegmentToReplicaToServerMap(Map<String, Map<Integer, String>> segmentToReplicaToServerMap) {
     _segmentToReplicaToServerMap = segmentToReplicaToServerMap;
@@ -71,7 +70,6 @@ public abstract class BasePartitionAwareRoutingTableBuilder implements RoutingTa
 
   @Override
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    _tableConfig = tableConfig;
     _propertyStore = propertyStore;
 
     // TODO: We need to specify the type of pruners via config instead of hardcoding.

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
@@ -89,6 +89,12 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
     ReplicaGroupPartitionAssignment partitionAssignment =
         partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(tableName);
 
+    // Update numReplicas if the replica group partition assignment has been changed.
+    int numReplicas = partitionAssignment.getNumReplicaGroups();
+    if (_numReplicas != numReplicas) {
+      _numReplicas = numReplicas;
+    }
+
     // 1. Compute the partition id set by looking at the segment zk metadata and cache metadata when possible
     Set<Integer> partitionIds = new HashSet<>();
     for (String segmentName : segmentSet) {

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -48,7 +48,7 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
   @Override
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     super.init(configuration, tableConfig, propertyStore);
-    _numReplicas = Integer.valueOf(_tableConfig.getValidationConfig().getReplicasPerPartition());
+    _numReplicas = Integer.valueOf(tableConfig.getValidationConfig().getReplicasPerPartition());
   }
 
   @Override

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -94,14 +94,14 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
       }
 
       // Update replica group mapping zk metadata
-      updatePartitionMappingZkMetadata(OFFLINE_TABLE_NAME, fakePropertyStore);
+      updatgeReplicaGroupPartitionAssignment(OFFLINE_TABLE_NAME, fakePropertyStore);
 
       // Create the fake external view
       ExternalView externalView = buildExternalView(OFFLINE_TABLE_NAME, replicaToServerMapping);
 
       // Create instance Configs
       List<InstanceConfig> instanceConfigs = new ArrayList<>();
-      for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+      for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
         String serverName = "Server_localhost_" + serverId;
         instanceConfigs.add(new InstanceConfig(serverName));
       }
@@ -151,12 +151,86 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     }
   }
 
-  private void updatePartitionMappingZkMetadata(String tableNameWithType, FakePropertyStore propertyStore) {
+  @Test
+  public void testRoutingTableAfterRebalance() throws Exception {
+    NUM_REPLICA = 1;
+    NUM_PARTITION = 1;
+    NUM_SERVERS = 1;
+    NUM_SEGMENTS = 10;
+
+    // Create the fake property store
+    FakePropertyStore fakePropertyStore = new FakePropertyStore();
+
+    // Create the table config, partition mapping,
+    TableConfig tableConfig = buildOfflineTableConfig();
+
+    // Create the replica group id to server mapping
+    Map<Integer, List<String>> replicaToServerMapping = buildReplicaGroupMapping();
+
+    // Update segment zk metadata.
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      String segmentName = "segment" + i;
+      int partition = i % NUM_PARTITION;
+      SegmentZKMetadata metadata = buildOfflineSegmentZKMetadata(segmentName, partition);
+      fakePropertyStore.setContents(
+          ZKMetadataProvider.constructPropertyStorePathForSegment(OFFLINE_TABLE_NAME, segmentName),
+          metadata.toZNRecord());
+    }
+
+    // Update replica group mapping zk metadata
+    updatgeReplicaGroupPartitionAssignment(OFFLINE_TABLE_NAME, fakePropertyStore);
+
+    // Create the fake external view
+    ExternalView externalView = buildExternalView(OFFLINE_TABLE_NAME, replicaToServerMapping);
+
+    // Create instance Configs
+    List<InstanceConfig> instanceConfigs = new ArrayList<>();
+    for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
+      String serverName = "Server_localhost_" + serverId;
+      instanceConfigs.add(new InstanceConfig(serverName));
+    }
+
+    // Create the partition aware offline routing table builder.
+    RoutingTableBuilder routingTableBuilder =
+        buildPartitionAwareOfflineRoutingTableBuilder(fakePropertyStore, tableConfig, externalView, instanceConfigs);
+
+    // Simulate the case where we add 1 more server/replica
+    NUM_REPLICA = 2;
+    NUM_SERVERS = 2;
+
+    // Update instance configs
+    String newServerName = "Server_localhost_" + (NUM_SERVERS - 1);
+    instanceConfigs.add(new InstanceConfig(newServerName));
+
+    // Update replica group partition assignment
+    updatgeReplicaGroupPartitionAssignment(OFFLINE_TABLE_NAME, fakePropertyStore);
+
+    // Update external view
+    Map<Integer, List<String>> newReplicaToServerMapping = buildReplicaGroupMapping();
+    ExternalView newExternalView = buildExternalView(OFFLINE_TABLE_NAME, newReplicaToServerMapping);
+
+    // Compute routing table and this should not throw null pointer exception
+    routingTableBuilder.computeRoutingTableFromExternalView(OFFLINE_TABLE_NAME, newExternalView, instanceConfigs);
+
+    Set<String> servers = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      String countStarQuery = "select count(*) from myTable";
+      Map<String, List<String>> routingTable =
+          routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery));
+      Assert.assertEquals(routingTable.keySet().size(), 1);
+      servers.add(routingTable.keySet().iterator().next());
+    }
+
+    // Check if both servers are get picked
+    Assert.assertEquals(servers.size(), 2);
+  }
+
+  private void updatgeReplicaGroupPartitionAssignment(String tableNameWithType, FakePropertyStore propertyStore) {
     // Create partition assignment mapping table.
     ReplicaGroupPartitionAssignment replicaGroupPartitionAssignment = new ReplicaGroupPartitionAssignment(tableNameWithType);
 
     int partitionId = 0;
-    for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+    for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
       String serverName = "Server_localhost_" + serverId;
       int replicaGroupId = serverId / (NUM_SERVERS / NUM_REPLICA);
       replicaGroupPartitionAssignment.addInstanceToReplicaGroup(partitionId, replicaGroupId, serverName);


### PR DESCRIPTION
Mirror of linkedin pinot#2806
PartitionAwareOfflineRoutingTableBuilder was caching the number of replicas
from the table config during the initialization and never updates the value
even if there was a change. This caused NPE when the broker attempts to compute
routing table after servers were added to table and rebalance was invoked.
This PR addresses this bug and also added the unit test to make sure the fix
resolves the issue.
