### PR TITLE
Mirror of linkedin pinot#2801

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
@@ -86,7 +86,7 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
   }
 
   @Override
-  public void put(@Nonnull SchedulerQueryContext query) throws OutOfCapacityError {
+  public void put(@Nonnull SchedulerQueryContext query) throws OutOfCapacityException {
     Preconditions.checkNotNull(query);
     queueLock.lock();
     String groupName = groupSelector.getSchedulerGroupName(query);
@@ -205,10 +205,10 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
     return query;
   }
 
-  private void checkGroupHasCapacity(SchedulerGroup groupContext) throws OutOfCapacityError {
+  private void checkGroupHasCapacity(SchedulerGroup groupContext) throws OutOfCapacityException {
     if (groupContext.numPending() >= maxPendingPerGroup &&
         groupContext.totalReservedThreads() >= resourceManager.getTableThreadsHardLimit()) {
-      throw new OutOfCapacityError(
+      throw new OutOfCapacityException(
           String.format("SchedulerGroup %s is out of capacity. numPending: %d, maxPending: %d, reservedThreads: %d threadsHardLimit: %d",
               groupContext.name(),
               groupContext.numPending(), maxPendingPerGroup,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/OutOfCapacityException.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/OutOfCapacityException.java
@@ -18,9 +18,9 @@ package com.linkedin.pinot.core.query.scheduler;
 /**
  * Indicates that the scheduler queue is out of capacity
  */
-public class OutOfCapacityError extends Exception {
+public class OutOfCapacityException extends Exception {
 
-  public OutOfCapacityError(String msg) {
+  public OutOfCapacityException(String msg) {
     super(msg);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/PriorityScheduler.java
@@ -70,7 +70,7 @@ public abstract class PriorityScheduler extends QueryScheduler {
     final SchedulerQueryContext schedQueryContext = new SchedulerQueryContext(queryRequest);
     try {
       queryQueue.put(schedQueryContext);
-    } catch (OutOfCapacityError e) {
+    } catch (OutOfCapacityException e) {
       LOGGER.error("Out of capacity for table {}, message: {}", queryRequest.getTableName(), e.getMessage());
       return immediateErrorResponse(queryRequest, QueryException.SERVER_OUT_OF_CAPACITY_ERROR);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerPriorityQueue.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerPriorityQueue.java
@@ -30,11 +30,11 @@ public interface SchedulerPriorityQueue {
    * throws exception if the queues are out of capacity. This will never block for
    * resources to become available.
    * @param query query to add to the list of waiters
-   * @throws OutOfCapacityError if the internal query queues are full
+   * @throws OutOfCapacityException if the internal query queues are full
    */
   // TODO: throw OutOfCapacity or drop from the front of the queue ?
   // It may be more beneficial to drop oldest queries to move forward
-  void put(@Nonnull SchedulerQueryContext query) throws OutOfCapacityError;
+  void put(@Nonnull SchedulerQueryContext query) throws OutOfCapacityException;
 
   /**
    * Blocking call to select the query with highest priority to schedule for execution next.

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueueTest.java
@@ -51,7 +51,7 @@ public class MultiLevelPriorityQueueTest {
   }
 
   @Test
-  public void testSimplePutTake() throws OutOfCapacityError {
+  public void testSimplePutTake() throws OutOfCapacityException {
     MultiLevelPriorityQueue queue = createQueue();
     // NOTE: Timing matters here...running through debugger for
     // over 30 seconds can cause the query to expire
@@ -69,7 +69,7 @@ public class MultiLevelPriorityQueueTest {
   }
 
   @Test
-  public void testPutOutOfCapacity() throws OutOfCapacityError {
+  public void testPutOutOfCapacity() throws OutOfCapacityException {
     PropertiesConfiguration conf = new PropertiesConfiguration();
     conf.setProperty(MultiLevelPriorityQueue.MAX_PENDING_PER_GROUP_KEY, 2);
     ResourceManager rm = new UnboundedResourceManager(conf);
@@ -84,7 +84,7 @@ public class MultiLevelPriorityQueueTest {
     // it should throw now
     try {
       queue.put(createQueryRequest(groupOne, metrics));
-    } catch (OutOfCapacityError e) {
+    } catch (OutOfCapacityException e) {
       assertTrue(true);
       return;
     }
@@ -108,7 +108,7 @@ public class MultiLevelPriorityQueueTest {
   }
 
   @Test
-  public void testTakeWithLimits() throws OutOfCapacityError, BrokenBarrierException, InterruptedException {
+  public void testTakeWithLimits() throws OutOfCapacityException, BrokenBarrierException, InterruptedException {
     // Test that take() will not return query if that group is already using hardLimit resources
     PropertiesConfiguration conf = new PropertiesConfiguration();
     conf.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, 40);
@@ -177,7 +177,7 @@ public class MultiLevelPriorityQueueTest {
   }
 
   @Test
-  public void testNoPendingAfterTrim() throws OutOfCapacityError, BrokenBarrierException, InterruptedException {
+  public void testNoPendingAfterTrim() throws OutOfCapacityException, BrokenBarrierException, InterruptedException {
     MultiLevelPriorityQueue queue = createQueue();
     queue.put(createQueryRequest(groupOne, metrics));
     queue.put(createQueryRequest(groupTwo, metrics));


### PR DESCRIPTION
Mirror of linkedin pinot#2801
Remove misleading Error from the OutOfCapacityError class name, as it is
an exception, not an error.
