### PR TITLE
Mirror of linkedin pinot#2794

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -53,6 +53,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   private SegmentPartitionMetadata _partitionMetadata;
   private long _segmentUploadStartTime = -1;
   private Map<String, String> _customMap;
+  private String _segmentVersionUUID;
 
   public SegmentZKMetadata() {
   }
@@ -84,6 +85,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     }
     _segmentUploadStartTime = znRecord.getLongField(CommonConstants.Segment.SEGMENT_UPLOAD_START_TIME, -1);
     _customMap = znRecord.getMapField(CommonConstants.Segment.CUSTOM_MAP);
+    _segmentVersionUUID = znRecord.getSimpleField(CommonConstants.Segment.SEGMENT_VERSION_UUID);
   }
 
   public String getSegmentName() {
@@ -206,6 +208,14 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     _customMap = customMap;
   }
 
+  public String getSegmentVersionUUID() {
+    return _segmentVersionUUID;
+  }
+
+  public void setSegmentVersionUUID(String segmentVersionUUID) {
+    _segmentVersionUUID = segmentVersionUUID;
+  }
+
   @Override
   public boolean equals(Object segmentMetadata) {
     if (isSameReference(this, segmentMetadata)) {
@@ -222,7 +232,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
         metadata._startTime) && isEqual(_endTime, metadata._endTime) && isEqual(_segmentType, metadata._segmentType)
         && isEqual(_totalRawDocs, metadata._totalRawDocs) && isEqual(_crc, metadata._crc) && isEqual(_creationTime,
         metadata._creationTime) && isEqual(_partitionMetadata, metadata._partitionMetadata) && isEqual(
-        _segmentUploadStartTime, metadata._segmentUploadStartTime) && isEqual(_customMap, metadata._customMap);
+        _segmentUploadStartTime, metadata._segmentUploadStartTime) && isEqual(_customMap, metadata._customMap) && isEqual(
+        _segmentVersionUUID, metadata._segmentVersionUUID);
   }
 
   @Override
@@ -240,6 +251,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     result = hashCodeOf(result, _partitionMetadata);
     result = hashCodeOf(result, _segmentUploadStartTime);
     result = hashCodeOf(result, _customMap);
+    result = hashCodeOf(result, _segmentVersionUUID);
     return result;
   }
 
@@ -277,6 +289,9 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     }
     if (_customMap != null) {
       znRecord.setMapField(CommonConstants.Segment.CUSTOM_MAP, _customMap);
+    }
+    if (_segmentVersionUUID != null) {
+      znRecord.setSimpleField(CommonConstants.Segment.SEGMENT_VERSION_UUID, _segmentVersionUUID);
     }
     return znRecord;
   }
@@ -320,6 +335,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
       JSONObject jsonObject = new JSONObject(_customMap);
       configMap.put(CommonConstants.Segment.CUSTOM_MAP, jsonObject.toString());
     }
+
+    configMap.put(CommonConstants.Segment.SEGMENT_VERSION_UUID, _segmentVersionUUID);
 
     return configMap;
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -323,6 +323,11 @@ public class CommonConstants {
 
     public static final String CUSTOM_MAP = "custom.map";
 
+    /**
+     * This field will uniquely identify the version of the segment with a random UUID.
+     */
+    public static final String SEGMENT_VERSION_UUID = "segment.version.uuid";
+
     public static final String SEGMENT_BACKUP_DIR_SUFFIX = ".segment.bak";
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -56,6 +56,12 @@ public class ControllerConf extends PropertiesConfiguration {
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   private static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
 
+  // Storage Parameters
+  // This parameter allows users to configure the base directory where all pinot segments will be stored
+  private static final String STORAGE_DIR = "controller.storage.dir";
+  // Defines the kind of storage and the underlying PinotFS implementation; each storage type will have a different factory class
+  private static final String PINOT_FS_FACTORY_CLASS = "controller.storage.factory.class";
+
   private static final int DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
   private static final int DEFAULT_VALIDATION_CONTROLLER_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
   private static final int DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
@@ -72,6 +78,11 @@ public class ControllerConf extends PropertiesConfiguration {
       "com.linkedin.pinot.controller.api.access.AllowAllAccessFactory";
   private static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
 
+  // Default Storage Parameters
+  // Current default for pinot fs is local implementation
+  private static final String DEFAULT_PINOT_FS_FACTORY_CLASS =
+      "com.linkedin.pinot.controller.api.storage.LocalPinotFSFactory";
+
   public ControllerConf(File file) throws ConfigurationException {
     super(file);
   }
@@ -87,6 +98,14 @@ public class ControllerConf extends PropertiesConfiguration {
       // Shouldn't happen
       throw new AssertionError("UTF-8 encoding should always be supported", e);
     }
+  }
+
+  public void setPinotStorageDir(String dir) {
+    setProperty(STORAGE_DIR, dir);
+  }
+
+  public void setPinotFSFactoryClass(String pinotFSFactoryClass) {
+    setProperty(PINOT_FS_FACTORY_CLASS, pinotFSFactoryClass);
   }
 
   public void setSplitCommit(boolean isSplitCommit) {
@@ -207,6 +226,14 @@ public class ControllerConf extends PropertiesConfiguration {
   @Override
   public String toString() {
     return super.toString();
+  }
+
+  public String getPinotStorageDir() {
+    return getString(STORAGE_DIR, null);
+  }
+
+  public String getPinotFSFactoryClass() {
+    return getString(PINOT_FS_FACTORY_CLASS, DEFAULT_PINOT_FS_FACTORY_CLASS);
   }
 
   public boolean getAcceptSplitCommit() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -64,6 +64,7 @@ public class ControllerStarter {
   private static final Long DATA_DIRECTORY_MISSING_VALUE = 1000000L;
   private static final Long DATA_DIRECTORY_EXCEPTION_VALUE = 1100000L;
   private static final String METADATA_EVENT_NOTIFIER_PREFIX = "metadata.event.notifier";
+  private static final String STORAGE_PREFIX = "storage";
 
   private final ControllerConf _config;
   private final ControllerAdminApiApplication _adminApp;
@@ -178,14 +179,7 @@ public class ControllerStarter {
       throw new RuntimeException("Caught exception while creating new AccessControlFactory instance", e);
     }
 
-    String pinotFSFactoryClass = _config.getPinotFSFactoryClass();
-    LOGGER.info("Use class: {} as the PinotFSFactory", pinotFSFactoryClass);
-    final PinotFSFactory pinotFSFactory;
-    try {
-      pinotFSFactory = (PinotFSFactory) Class.forName(pinotFSFactoryClass).newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException("Caught exception while creating new PinotFSFactory instance", e);
-    }
+    final PinotFSFactory pinotFSFactory = PinotFSFactory.loadFactory(_config.subset(STORAGE_PREFIX));
 
     final MetadataEventNotifierFactory metadataEventNotifierFactory =
         MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX));

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -28,6 +28,7 @@ import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.controller.api.ControllerAdminApiApplication;
 import com.linkedin.pinot.controller.api.access.AccessControlFactory;
 import com.linkedin.pinot.controller.api.events.MetadataEventNotifierFactory;
+import com.linkedin.pinot.controller.api.storage.PinotFSFactory;
 import com.linkedin.pinot.controller.helix.SegmentStatusChecker;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
@@ -177,6 +178,15 @@ public class ControllerStarter {
       throw new RuntimeException("Caught exception while creating new AccessControlFactory instance", e);
     }
 
+    String pinotFSFactoryClass = _config.getPinotFSFactoryClass();
+    LOGGER.info("Use class: {} as the PinotFSFactory", pinotFSFactoryClass);
+    final PinotFSFactory pinotFSFactory;
+    try {
+      pinotFSFactory = (PinotFSFactory) Class.forName(pinotFSFactoryClass).newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while creating new PinotFSFactory instance", e);
+    }
+
     final MetadataEventNotifierFactory metadataEventNotifierFactory =
         MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX));
 
@@ -198,6 +208,7 @@ public class ControllerStarter {
         bind(_executorService).to(Executor.class);
         bind(_controllerMetrics).to(ControllerMetrics.class);
         bind(accessControlFactory).to(AccessControlFactory.class);
+        bind(pinotFSFactory).to(PinotFSFactory.class);
         bind(metadataEventNotifierFactory).to(MetadataEventNotifierFactory.class);
       }
     });

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerApplicationException.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerApplicationException.java
@@ -21,21 +21,21 @@ import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 
 
-class ControllerApplicationException extends WebApplicationException {
+public class ControllerApplicationException extends WebApplicationException {
 
-  ControllerApplicationException(Logger logger, String message, Response.Status status) {
+  public ControllerApplicationException(Logger logger, String message, Response.Status status) {
     this(logger, message, status.getStatusCode(), null);
   }
 
-  ControllerApplicationException(Logger logger, String message, int status) {
+  public ControllerApplicationException(Logger logger, String message, int status) {
     this(logger, message, status, null);
   }
 
-  ControllerApplicationException(Logger logger, String message, Response.Status status, @Nullable Throwable e) {
+  public ControllerApplicationException(Logger logger, String message, Response.Status status, @Nullable Throwable e) {
     this(logger, message, status.getStatusCode(), e);
   }
 
-  ControllerApplicationException(Logger logger, String message, int status, @Nullable Throwable e) {
+  public ControllerApplicationException(Logger logger, String message, int status, @Nullable Throwable e) {
     super(message, status);
     if (status >= 300 && status < 500) {
       if (e == null) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import java.io.File;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.controller.api.storage;
 
 import java.io.File;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.commons.configuration.Configuration;
@@ -26,53 +25,50 @@ import org.apache.commons.configuration.Configuration;
  * Local implementation of the Pinot filesystem
  */
 public class LocalPinotFS implements PinotFS {
-  public static String _storageDir;
-  public static final String PINOT_FS_STORAGE_LOCATION = "dir";
 
   public LocalPinotFS() {
   }
 
   public void init(Configuration configuration) {
-    _storageDir = configuration.getString(PINOT_FS_STORAGE_LOCATION);
   }
 
-  public boolean delete(URI uri) throws Exception {
-    File file = new File(_storageDir, uri.getPath());
+  public boolean delete(String location) throws Exception {
+    File file = new File(location);
     return file.delete();
   }
 
-  public boolean move(URI srcUri, URI dstUri) throws Exception {
-    Files.move(Paths.get(_storageDir, srcUri.toString()), Paths.get(_storageDir, dstUri.toString()));
+  public boolean move(String src, String dst) throws Exception {
+    Files.move(Paths.get(src.toString()), Paths.get(dst.toString()));
     return true;
   }
 
-  public boolean copy(URI srcUri, URI dstUri) throws Exception {
-    Files.copy(Paths.get(_storageDir, srcUri.toString()), Paths.get(_storageDir, dstUri.toString()));
+  public boolean copy(String src, String dst) throws Exception {
+    Files.copy(Paths.get(src.toString()), Paths.get(dst.toString()));
     return true;
   }
 
-  public boolean exists(URI uri) {
-    File file = new File(_storageDir, uri.getPath());
+  public boolean exists(String location) {
+    File file = new File(location);
     return file.exists();
   }
 
-  public long length(URI uri) {
-    File file = new File(_storageDir, uri.getPath());
+  public long length(String location) {
+    File file = new File(location);
     return file.length();
   }
 
-  public String[] listFiles(URI uri) {
-    File file = new File(_storageDir, uri.getPath());
+  public String[] listFiles(String location) {
+    File file = new File(location);
     return file.list();
   }
 
-  public String getParentFile(URI uri) {
-    File file = new File(_storageDir, uri.getPath());
+  public String getParentFile(String location) {
+    File file = new File(location);
     return file.getParentFile().getPath();
   }
 
-  public String getName(URI uri) {
-    File file = new File(_storageDir, uri.getPath());
+  public String getName(String location) {
+    File file = new File(location);
     return file.getName();
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
@@ -16,9 +16,8 @@
 package com.linkedin.pinot.controller.api.storage;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.FileUtils;
 
 
 /**
@@ -34,17 +33,31 @@ public class LocalPinotFS implements PinotFS {
 
   public boolean delete(String location) throws Exception {
     File file = new File(location);
+    if (file.isDirectory()) {
+      FileUtils.deleteDirectory(file);
+      return true;
+    }
     return file.delete();
   }
 
   public boolean move(String src, String dst) throws Exception {
-    Files.move(Paths.get(src.toString()), Paths.get(dst.toString()));
-    return true;
+    File srcFile = new File(src);
+    File dstFile = new File(dst);
+    dstFile.getParentFile().mkdirs();
+    if (srcFile.renameTo(dstFile) && srcFile.delete()) {
+      return true;
+    }
+    return false;
   }
 
   public boolean copy(String src, String dst) throws Exception {
-    Files.copy(Paths.get(src.toString()), Paths.get(dst.toString()));
-    return true;
+    File srcFile = new File(src);
+    File dstFile = new File(dst);
+    dstFile.getParentFile().mkdirs();
+    if (srcFile.renameTo(dstFile)) {
+      return true;
+    }
+    return false;
   }
 
   public boolean exists(String location) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFS.java
@@ -1,0 +1,63 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.apache.commons.configuration.Configuration;
+
+
+/**
+ * Local implementation of the Pinot filesystem
+ */
+public class LocalPinotFS implements PinotFS {
+  public static String _storageDir;
+  public static final String PINOT_FS_STORAGE_LOCATION = "dir";
+
+  public LocalPinotFS() {
+  }
+
+  public void init(Configuration configuration) {
+    _storageDir = configuration.getString(PINOT_FS_STORAGE_LOCATION);
+  }
+
+  public boolean delete(URI uri) throws Exception {
+    File file = new File(_storageDir, uri.getPath());
+    return file.delete();
+  }
+
+  public boolean move(URI srcUri, URI dstUri) throws Exception {
+    Files.move(Paths.get(_storageDir, srcUri.toString()), Paths.get(_storageDir, dstUri.toString()));
+    return true;
+  }
+
+  public boolean copy(URI srcUri, URI dstUri) throws Exception {
+    Files.copy(Paths.get(_storageDir, srcUri.toString()), Paths.get(_storageDir, dstUri.toString()));
+    return true;
+  }
+
+  public boolean exists(URI uri) {
+    File file = new File(_storageDir, uri.getPath());
+    return file.exists();
+  }
+
+  public long length(URI uri) {
+    File file = new File(_storageDir, uri.getPath());
+    return file.length();
+  }
+
+  public String[] listFiles(URI uri) {
+    File file = new File(_storageDir, uri.getPath());
+    return file.list();
+  }
+
+  public String getParentFile(URI uri) {
+    File file = new File(_storageDir, uri.getPath());
+    return file.getParentFile().getPath();
+  }
+
+  public String getName(URI uri) {
+    File file = new File(_storageDir, uri.getPath());
+    return file.getName();
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFSFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFSFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import org.apache.commons.configuration.Configuration;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFSFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/LocalPinotFSFactory.java
@@ -1,0 +1,22 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import org.apache.commons.configuration.Configuration;
+
+
+/**
+ * Factory to initialize the LocalPinotFS filesystem implementation.
+ */
+public class LocalPinotFSFactory extends PinotFSFactory {
+  private final PinotFS _pinotFS;
+  public LocalPinotFSFactory() {
+    _pinotFS = new LocalPinotFS();
+  }
+
+  public void init(Configuration configuration) {
+    _pinotFS.init(configuration);
+  }
+
+  public PinotFS create() {
+    return _pinotFS;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFS.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.controller.api.storage;
 
-import java.net.URI;
 import org.apache.commons.configuration.Configuration;
 
 /**
@@ -31,69 +30,69 @@ public interface PinotFS {
   void init(Configuration config);
 
   /**
-   * Deletes the file at the uri provided
-   * @param uri
+   * Deletes the file at the location provided
+   * @param location
    * @return
    * @throws Exception
    */
-  boolean delete(URI uri) throws Exception;
+  boolean delete(String location) throws Exception;
 
   /**
-   * Moves the file from the srcUri to the dstUri. Does not keep the original file. If the dstUri has parent directories
+   * Moves the file from the src to dst. Does not keep the original file. If the dst has parent directories
    * that haven't been created, this method will create all the necessary parent directories.
-   * @param srcUri
-   * @param dstUri
+   * @param src
+   * @param dst
    * @return
    * @throws Exception
    */
-  boolean move(URI srcUri, URI dstUri) throws Exception;
+  boolean move(String src, String dst) throws Exception;
 
   /**
-   * Copies a file from srcUri to dstUri. Keeps the original file. If the dstUri has parent directories that haven't
+   * Copies a file from src to dst. Keeps the original file. If the dst has parent directories that haven't
    * been created, this method will create all the necessary parent directories.
-   * @param srcUri
-   * @param dstUri
+   * @param src
+   * @param dst
    * @return
    * @throws Exception
    */
-  boolean copy(URI srcUri, URI dstUri) throws Exception;
+  boolean copy(String src, String dst) throws Exception;
 
   /**
-   * Checks whether the file at the provided uri exists.
-   * @param uri
+   * Checks whether the file at the provided location exists.
+   * @param location
    * @return
    */
-  boolean exists(URI uri);
+  boolean exists(String location);
 
   /**
-   * Returns the length of the file at the provided uri.
-   * @param uri
+   * Returns the length of the file at the provided location.
+   * @param location
    * @return
    */
-  long length(URI uri);
+  long length(String location);
 
   /**
-   * Lists all the files at the URI provided. Returns null if this abstract pathname does not denote a directory, or if
+   * Lists all the files at the location provided. Returns null if this abstract pathname does not denote a directory, or if
    * an I/O error occurs.
-   * @param uri
+   * @param location
    * @return
    */
-  String[] listFiles(URI uri);
+  String[] listFiles(String location);
 
   /**
    * Returns the abstract pathname of this abstract pathname's parent, or null if this pathname does not name a parent
    * directory. The parent consists of the pathname's prefix, if any, and each name in the pathname's name sequence
    * except for the last. If the name sequence is empty, then the pathname does not name a parent directory.
-   * @param uri
+   * @param location
    * @return
    */
-  String getParentFile(URI uri);
+  String getParentFile(String location);
 
   /**
    * Returns the name of the file or directory denoted by this abstract pathname. This is just the last name in the
    * pathname's name sequence. If the pathname's name sequence is empty, then the empty string is returned.
-   * @param uri
+   * @param location
    * @return
    */
-  String getName(URI uri);
+  String getName(String location);
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFS.java
@@ -1,0 +1,84 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import java.net.URI;
+import org.apache.commons.configuration.Configuration;
+
+/**
+ * The PinotFS is intended to be a thin wrapper on top of different filesystems. Each storage type that is implemented
+ * will implement this class for filesystem-specific operations
+ */
+public interface PinotFS {
+  /**
+   * Initializes the configurations specific to that filesystem. For instance, any security related parameters can be
+   * initialized here
+   * @param config
+   */
+  void init(Configuration config);
+
+  /**
+   * Deletes the file at the uri provided
+   * @param uri
+   * @return
+   * @throws Exception
+   */
+  boolean delete(URI uri) throws Exception;
+
+  /**
+   * Moves the file from the srcUri to the dstUri. Does not keep the original file. If the dstUri has parent directories
+   * that haven't been created, this method will create all the necessary parent directories.
+   * @param srcUri
+   * @param dstUri
+   * @return
+   * @throws Exception
+   */
+  boolean move(URI srcUri, URI dstUri) throws Exception;
+
+  /**
+   * Copies a file from srcUri to dstUri. Keeps the original file. If the dstUri has parent directories that haven't
+   * been created, this method will create all the necessary parent directories.
+   * @param srcUri
+   * @param dstUri
+   * @return
+   * @throws Exception
+   */
+  boolean copy(URI srcUri, URI dstUri) throws Exception;
+
+  /**
+   * Checks whether the file at the provided uri exists.
+   * @param uri
+   * @return
+   */
+  boolean exists(URI uri);
+
+  /**
+   * Returns the length of the file at the provided uri.
+   * @param uri
+   * @return
+   */
+  long length(URI uri);
+
+  /**
+   * Lists all the files at the URI provided. Returns null if this abstract pathname does not denote a directory, or if
+   * an I/O error occurs.
+   * @param uri
+   * @return
+   */
+  String[] listFiles(URI uri);
+
+  /**
+   * Returns the abstract pathname of this abstract pathname's parent, or null if this pathname does not name a parent
+   * directory. The parent consists of the pathname's prefix, if any, and each name in the pathname's name sequence
+   * except for the last. If the name sequence is empty, then the pathname does not name a parent directory.
+   * @param uri
+   * @return
+   */
+  String getParentFile(URI uri);
+
+  /**
+   * Returns the name of the file or directory denoted by this abstract pathname. This is just the last name in the
+   * pathname's name sequence. If the pathname's name sequence is empty, then the empty string is returned.
+   * @param uri
+   * @return
+   */
+  String getName(URI uri);
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFS.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFS.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import java.net.URI;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFSFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFSFactory.java
@@ -1,0 +1,35 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Initializes the PinotFS implementation.
+ */
+public abstract class PinotFSFactory {
+  public static final Logger LOGGER = LoggerFactory.getLogger(PinotFSFactory.class);
+  public static final String PINOT_FS_CLASS_CONFIG = "class";
+
+  public abstract void init(Configuration configuration);
+
+  public abstract PinotFS create();
+
+  public static PinotFSFactory loadFactory(Configuration configuration) {
+    PinotFSFactory pinotFSFactory;
+    String pinotFSFactoryClassName = configuration.getString(PINOT_FS_CLASS_CONFIG);
+    if (pinotFSFactoryClassName == null) {
+      pinotFSFactoryClassName = LocalPinotFSFactory.class.getName();
+    }
+    try {
+      LOGGER.info("Instantiating Pinot FS factory class {}", pinotFSFactoryClassName);
+      pinotFSFactory =  (PinotFSFactory) Class.forName(pinotFSFactoryClassName).newInstance();
+      LOGGER.info("Initializing Pinot FS factory class {}", pinotFSFactoryClassName);
+      pinotFSFactory.init(configuration);
+      return pinotFSFactory;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFSFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotFSFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import org.apache.commons.configuration.Configuration;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotSegmentUploadUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotSegmentUploadUtils.java
@@ -1,0 +1,256 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
+import com.linkedin.pinot.common.metrics.ControllerMeter;
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.SegmentName;
+import com.linkedin.pinot.common.utils.time.TimeUtils;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.api.access.AccessControlFactory;
+import com.linkedin.pinot.controller.api.resources.ControllerApplicationException;
+import com.linkedin.pinot.controller.api.resources.SuccessResponse;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import java.net.URI;
+import java.util.Date;
+import java.util.concurrent.Executor;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.helix.ZNRecord;
+import org.joda.time.Interval;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Contains upload-specific methods
+ */
+public class PinotSegmentUploadUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentUploadUtils.class);
+
+  @Inject
+  PinotHelixResourceManager _pinotHelixResourceManager;
+
+  @Inject
+  ControllerConf _controllerConf;
+
+  @Inject
+  ControllerMetrics _controllerMetrics;
+
+  @Inject
+  HttpConnectionManager _connectionManager;
+
+  @Inject
+  Executor _executor;
+
+  @Inject
+  AccessControlFactory _accessControlFactory;
+
+  @Inject
+  PinotFSFactory _pinotFSFactory;
+
+  /**
+   * Updates zk metadata and allows segment to start serving queries
+   * @param segmentMetadata
+   * @param dstUri final uploaded location of the segment
+   * @param segmentUploaderConfig
+   */
+  public void pushMetadata(SegmentMetadata segmentMetadata, URI dstUri, SegmentUploaderConfig segmentUploaderConfig)
+      throws JSONException {
+    PinotFS pinotFS = createPinotFS();
+    HttpHeaders headers = segmentUploaderConfig.getHeaders();
+    String tableName = segmentMetadata.getTableName();
+    String segmentName = segmentMetadata.getName();
+    String tableNameWithType = getTableNameWithType(segmentName, tableName);
+
+    ZNRecord znRecord = _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
+
+    // Segment is stored under its version directory
+    String segmentVersionUUID = getSegmentVersionUUID(dstUri, pinotFS);
+
+    // Brand new segment, not refresh, directly add the segment
+    if (znRecord == null) {
+      _pinotHelixResourceManager.addNewSegment(segmentMetadata, dstUri.toString(), segmentVersionUUID);
+      return;
+    }
+
+    // Segment already exists, refresh if necessary
+    OfflineSegmentZKMetadata existingSegmentZKMetadata = new OfflineSegmentZKMetadata(znRecord);
+    long existingCrc = existingSegmentZKMetadata.getCrc();
+
+    // Version of the current segment in zk
+    String currentSegmentVersionUUID = existingSegmentZKMetadata.getSegmentVersionUUID();
+
+    // Segment does not have any version, means should not call only metadata method, should have gone through the upload
+    if (segmentVersionUUID == null) {
+      throw new ControllerApplicationException(LOGGER,
+          "Segment location is not expected: " + segmentName + " of table: " + tableName, Response.Status.NOT_ACCEPTABLE);
+    }
+    if (!segmentVersionUUID.equals(currentSegmentVersionUUID)) {
+      // Different segment is in zk, reject push
+      throw new ControllerApplicationException(LOGGER,
+          "Another segment upload is in progress for segment: " + segmentName + " of table: " + tableName
+              + ", retry later", Response.Status.CONFLICT);
+    }
+
+    try {
+      // Modify the custom map in segment ZK metadata
+      String segmentZKMetadataCustomMapModifierStr = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER);
+      SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier;
+      if (segmentZKMetadataCustomMapModifierStr != null) {
+        segmentZKMetadataCustomMapModifier =
+            new SegmentZKMetadataCustomMapModifier(segmentZKMetadataCustomMapModifierStr);
+      } else {
+        // By default, use REPLACE modify mode
+        segmentZKMetadataCustomMapModifier =
+            new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.REPLACE, null);
+      }
+      existingSegmentZKMetadata.setCustomMap(
+          segmentZKMetadataCustomMapModifier.modifyMap(existingSegmentZKMetadata.getCustomMap()));
+
+      // Update ZK metadata and refresh the segment if necessary
+      long newCrc = Long.valueOf(segmentMetadata.getCrc());
+      if (newCrc == existingCrc) {
+        // New segment is the same as the existing one, only update ZK metadata without refresh the segment
+        if (!_pinotHelixResourceManager.updateZkMetadata(existingSegmentZKMetadata)) {
+          throw new RuntimeException(
+              "Failed to update ZK metadata for segment: " + segmentName + " of table: " + tableNameWithType);
+        }
+      } else {
+        _pinotHelixResourceManager.refreshSegment(segmentMetadata, existingSegmentZKMetadata, dstUri.toString(), segmentVersionUUID);
+      }
+    } catch (Exception e) {
+      if (!_pinotHelixResourceManager.updateZkMetadata(existingSegmentZKMetadata)) {
+        LOGGER.error("Failed to update ZK metadata for segment: {} of table: {}", segmentName, tableNameWithType);
+      }
+      throw e;
+    }
+  }
+
+  public SuccessResponse push(SegmentMetadata segmentMetadata, URI segmentUri, SegmentUploaderConfig segmentUploaderConfig) {
+    // Log information about the incoming segment
+    logIncomingSegmentInformation(segmentUploaderConfig.getHeaders());
+
+    PinotFS pinotFS = createPinotFS();
+    String storageDirectory = _controllerConf.getPinotStorageDir();
+    String tableName = segmentMetadata.getTableName();
+    String segmentName = segmentMetadata.getName();
+
+    // Check time range
+    if (!isSegmentTimeValid(segmentMetadata)) {
+      throw new ControllerApplicationException(LOGGER,
+          "Invalid segment start/end time for segment: " + segmentName + " of table: " + tableName, Response.Status.NOT_ACCEPTABLE);
+    }
+
+    checkQuota(segmentMetadata, getTableNameWithType(segmentName, tableName));
+
+    // Constructs permanent home of segment with a unique UUID. We will keep all versions of segments uploaded.
+    URI dstUri = PinotStorageUtils.constructSegmentLocation(storageDirectory, segmentMetadata);
+
+    try {
+      // Move segment to permanent directory
+      pinotFS.copy(segmentUri, dstUri);
+    } catch (Exception e) {
+      throw new RuntimeException("Could not construct destination URI");
+    }
+
+    try {
+      // Update zk segment metadata
+      pushMetadata(segmentMetadata, dstUri, segmentUploaderConfig);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
+      throw new ControllerApplicationException(LOGGER, "Caught internal server exception while uploading segment",
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+
+    return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableName);
+  }
+
+  private void checkQuota(SegmentMetadata segmentMetadata, String tableNameWithType) {
+    TableConfig tableConfig =
+        ZKMetadataProvider.getTableConfig(_pinotHelixResourceManager.getPropertyStore(), tableNameWithType);
+
+    if (tableConfig == null) {
+      throw new ControllerApplicationException(LOGGER, "Failed to find table config for table: " + tableNameWithType,
+          Response.Status.NOT_FOUND);
+    }
+
+    // TODO: Add quota check
+  }
+
+  private void logIncomingSegmentInformation(HttpHeaders headers) {
+    if (headers != null) {
+      // TODO: Add these headers into open source hadoop jobs
+      LOGGER.info("HTTP Header {} is {}", CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER,
+          headers.getRequestHeader(CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER));
+      LOGGER.info("HTTP Header {} is {}", CommonConstants.Controller.TABLE_NAME_HTTP_HEADER,
+          headers.getRequestHeader(CommonConstants.Controller.TABLE_NAME_HTTP_HEADER));
+    }
+  }
+
+  /**
+   * Returns true if:
+   * - Segment does not have a start/end time, OR
+   * - The start/end time are in a valid range (Jan 01 1971 - Jan 01, 2071)
+   * @param metadata Segment metadata
+   * @return
+   */
+  private boolean isSegmentTimeValid(SegmentMetadata metadata) {
+    Interval interval = metadata.getTimeInterval();
+    if (interval == null) {
+      return true;
+    }
+
+    long startMillis = interval.getStartMillis();
+    long endMillis = interval.getEndMillis();
+
+    if (!TimeUtils.timeValueInValidRange(startMillis) || !TimeUtils.timeValueInValidRange(endMillis)) {
+      Date minDate = new Date(TimeUtils.getValidMinTimeMillis());
+      Date maxDate = new Date(TimeUtils.getValidMaxTimeMillis());
+
+      LOGGER.error(
+          "Invalid start time '{}ms' or end time '{}ms' for segment {}, must be between '{}' and '{}' (timecolumn {}, timeunit {})",
+          interval.getStartMillis(), interval.getEndMillis(), metadata.getName(), minDate, maxDate,
+          metadata.getTimeColumn(), metadata.getTimeUnit().toString());
+      return false;
+    }
+
+    return true;
+  }
+
+  private String getTableNameWithType(String segmentName, String tableName) {
+    if (SegmentName.getSegmentType(segmentName).equals(SegmentName.RealtimeSegmentType.UNSUPPORTED)) {
+      // Offline segment
+      return TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    } else {
+      return TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    }
+  }
+
+  private String getSegmentVersionUUID(URI segmentUri, PinotFS pinotFS) {
+    try {
+      URI parentURI = new URI(pinotFS.getParentFile(segmentUri));
+      return pinotFS.getName(parentURI);
+    } catch (Exception e) {
+      LOGGER.error("Could not retrieve parent URI");
+      throw new ControllerApplicationException(LOGGER, "Invalid segment location for segment: " + segmentUri, Response.Status.BAD_REQUEST);
+    }
+  }
+
+  private PinotFS createPinotFS() {
+    return _pinotFSFactory.create();
+  }
+
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotSegmentUploadUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotSegmentUploadUtils.java
@@ -26,17 +26,14 @@ import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
 import com.linkedin.pinot.common.utils.SegmentName;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
 import com.linkedin.pinot.controller.ControllerConf;
-import com.linkedin.pinot.controller.api.access.AccessControlFactory;
 import com.linkedin.pinot.controller.api.resources.ControllerApplicationException;
 import com.linkedin.pinot.controller.api.resources.SuccessResponse;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import java.util.Date;
-import java.util.concurrent.Executor;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.helix.ZNRecord;
 import org.joda.time.Interval;
 import org.json.JSONException;
@@ -58,15 +55,6 @@ public class PinotSegmentUploadUtils {
 
   @Inject
   ControllerMetrics _controllerMetrics;
-
-  @Inject
-  HttpConnectionManager _connectionManager;
-
-  @Inject
-  Executor _executor;
-
-  @Inject
-  AccessControlFactory _accessControlFactory;
 
   @Inject
   PinotFSFactory _pinotFSFactory;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotSegmentUploadUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotSegmentUploadUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import com.linkedin.pinot.common.config.TableNameBuilder;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotStorageUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotStorageUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import com.linkedin.pinot.common.segment.SegmentMetadata;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotStorageUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotStorageUtils.java
@@ -1,0 +1,27 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.controller.api.resources.ControllerApplicationException;
+import java.net.URI;
+import java.util.UUID;
+import javax.ws.rs.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Helper methods for storage operations.
+ */
+public class PinotStorageUtils {
+  private static final String SLASH = "/";
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotStorageUtils.class);
+
+  public static URI constructSegmentLocation(String storageDirectory, SegmentMetadata segmentMetadata) {
+    try {
+      return new URI(storageDirectory + SLASH + segmentMetadata.getTableName() + SLASH + segmentMetadata.getName() + SLASH + UUID.randomUUID());
+    } catch (Exception e) {
+      LOGGER.info("Could not construct URI for segment {}", segmentMetadata.getName());
+      throw new ControllerApplicationException(LOGGER, "Could not construct segment location", Response.Status.NOT_FOUND);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotStorageUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/PinotStorageUtils.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.controller.api.storage;
 
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.controller.api.resources.ControllerApplicationException;
-import java.net.URI;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
@@ -31,9 +30,9 @@ public class PinotStorageUtils {
   private static final String SLASH = "/";
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotStorageUtils.class);
 
-  public static URI constructSegmentLocation(String storageDirectory, SegmentMetadata segmentMetadata) {
+  public static String constructSegmentLocation(String storageDirectory, SegmentMetadata segmentMetadata) {
     try {
-      return new URI(storageDirectory + SLASH + segmentMetadata.getTableName() + SLASH + segmentMetadata.getName() + SLASH + UUID.randomUUID());
+      return storageDirectory + SLASH + segmentMetadata.getTableName() + SLASH + segmentMetadata.getName() + SLASH + UUID.randomUUID();
     } catch (Exception e) {
       LOGGER.info("Could not construct URI for segment {}", segmentMetadata.getName());
       throw new ControllerApplicationException(LOGGER, "Could not construct segment location", Response.Status.NOT_FOUND);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/SegmentUploaderConfig.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/SegmentUploaderConfig.java
@@ -1,0 +1,49 @@
+package com.linkedin.pinot.controller.api.storage;
+
+import javax.ws.rs.core.HttpHeaders;
+import org.glassfish.grizzly.http.server.Request;
+
+
+/**
+ * Wrapper class that encapsulates all parameters sent by clients during segment upload
+ */
+public class SegmentUploaderConfig {
+  private final HttpHeaders _headers;
+  private final Request _request;
+
+
+  private SegmentUploaderConfig(HttpHeaders headers, Request request) {
+    _headers = headers;
+    _request = request;
+  }
+
+  public HttpHeaders getHeaders() {
+    return _headers;
+  }
+
+  public Request getRequest() {
+    return _request;
+  }
+
+  public static class SegmentUploaderConfigBuilder {
+    private HttpHeaders _headers;
+    private Request _request;
+
+    private SegmentUploaderConfigBuilder() {
+    }
+
+    public SegmentUploaderConfigBuilder setHeaders(HttpHeaders headers) {
+      _headers = headers;
+      return this;
+    }
+
+    public SegmentUploaderConfigBuilder setRequest(Request request) {
+      _request = request;
+      return this;
+    }
+
+    public SegmentUploaderConfig build() {
+      return new SegmentUploaderConfig(_headers, _request);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/SegmentUploaderConfig.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/storage/SegmentUploaderConfig.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.controller.api.storage;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -25,19 +40,19 @@ public class SegmentUploaderConfig {
     return _request;
   }
 
-  public static class SegmentUploaderConfigBuilder {
+  public static class Builder {
     private HttpHeaders _headers;
     private Request _request;
 
-    private SegmentUploaderConfigBuilder() {
+    public Builder() {
     }
 
-    public SegmentUploaderConfigBuilder setHeaders(HttpHeaders headers) {
+    public Builder setHeaders(HttpHeaders headers) {
       _headers = headers;
       return this;
     }
 
-    public SegmentUploaderConfigBuilder setRequest(Request request) {
+    public Builder setRequest(Request request) {
       _request = request;
       return this;
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
@@ -58,7 +58,7 @@ public abstract class ControllerTest {
 
   private static final int DEFAULT_CONTROLLER_PORT = 8998;
   private static final String DEFAULT_DATA_DIR =
-      FileUtils.getTempDirectoryPath() + File.separator + "test-controller-" + System.currentTimeMillis();
+      FileUtils.getTempDirectoryPath() + "test-controller-" + System.currentTimeMillis();
 
   protected int _controllerPort;
   protected String _controllerBaseApiUrl;
@@ -101,6 +101,7 @@ public abstract class ControllerTest {
     config.setDataDir(DEFAULT_DATA_DIR);
     config.setZkStr(ZkStarter.DEFAULT_ZK_STR);
     config.setPinotStorageDir(DEFAULT_DATA_DIR);
+    config.setPinotFSFactoryClass("com.linkedin.pinot.controller.api.storage.LocalPinotFSFactory");
     return config;
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
@@ -100,6 +100,7 @@ public abstract class ControllerTest {
     config.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT));
     config.setDataDir(DEFAULT_DATA_DIR);
     config.setZkStr(ZkStarter.DEFAULT_ZK_STR);
+    config.setPinotStorageDir(DEFAULT_DATA_DIR);
     return config;
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/storage/LocalPinotFSTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/storage/LocalPinotFSTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.storage;
+
+import com.linkedin.pinot.controller.api.storage.LocalPinotFS;
+import java.io.File;
+import junit.framework.Assert;
+import org.apache.commons.io.FileUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class LocalPinotFSTest {
+  LocalPinotFS _localPinotFS = new LocalPinotFS();
+  private static final File JAVA_TMPDIR = FileUtils.getTempDirectory();
+  private static final File TEMP_DIR = new File(JAVA_TMPDIR, "LocalPinotFSTest");
+  private static final File TEMP_DIR_COPY = new File(JAVA_TMPDIR, "LocalPinotFSTestTmp");
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    FileUtils.deleteDirectory(TEMP_DIR);
+    FileUtils.deleteDirectory(TEMP_DIR_COPY);
+    TEMP_DIR.mkdir();
+    File file = new File(TEMP_DIR, "segmentName");
+    file.createNewFile();
+  }
+
+  @Test
+  public void testFSOperations() throws Exception {
+    boolean copied = _localPinotFS.copy(TEMP_DIR.getPath(), TEMP_DIR_COPY.getPath());
+    Assert.assertTrue(copied);
+    boolean deleted = _localPinotFS.delete(TEMP_DIR_COPY.getPath());
+    Assert.assertTrue(deleted);
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    FileUtils.deleteDirectory(TEMP_DIR);
+    FileUtils.deleteDirectory(TEMP_DIR_COPY);
+  }}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/PinotSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/PinotSegmentUploadIntegrationTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.util.concurrent.MoreExecutors;
@@ -7,15 +22,14 @@ import com.linkedin.pinot.controller.api.storage.LocalPinotFSFactory;
 import com.linkedin.pinot.controller.api.storage.PinotFSFactory;
 import com.linkedin.pinot.controller.api.storage.PinotSegmentUploadUtils;
 import com.linkedin.pinot.controller.api.storage.SegmentUploaderConfig;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.lang.reflect.Field;
-import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
@@ -122,146 +136,6 @@ public class PinotSegmentUploadIntegrationTest extends BaseClusterIntegrationTes
     final String segment6 = "segmentToBeRefreshed_6";
     final int nRows1 = 69;
     generateAndUploadRandomSegment(segment6, nRows1);
-    verifyNRows(0, nRows1);
-    final int nRows2 = 198;
-    LOGGER.info("Segment {} loaded with {} rows, refreshing with {}", segment6, nRows1, nRows2);
-    generateAndUploadRandomSegment(segment6, nRows2);
-    verifyNRows(nRows1, nRows2);
-    // Load another segment while keeping this one in place.
-    final String segment9 = "newSegment_9";
-    final int nRows3 = 102;
-    generateAndUploadRandomSegment(segment9, nRows3);
-    verifyNRows(nRows2, nRows2+nRows3);
-  }
-
-  // Verify that the number of rows is either the initial value or the final value but not something else.
-  private void verifyNRows(int currentNrows, int finalNrows) throws Exception {
-    int attempt = 0;
-    long sleepTime = 100;
-    long nRows;
-    while (attempt < 10) {
-      Thread.sleep(sleepTime);
-      try {
-        nRows = getCurrentCountStarResult();
-      } catch (Exception e) {
-        nRows = -1;
-      }
-      //nRows can either be the current value or the final value, not any other.
-      if (nRows == currentNrows || nRows == -1) {
-        sleepTime *= 2;
-        attempt++;
-      } else if (nRows == finalNrows) {
-        return;
-      } else {
-        Assert.fail("Found unexpected number of rows " + nRows);
-      }
-    }
-    Assert.fail("Failed to get from " + currentNrows + " to " + finalNrows);
-  }
-
-  @Test(enabled = false, dataProvider = "configProvider")
-  public void testUploadRefreshDelete(String tableName, SegmentVersion version) throws Exception {
-    final int THREAD_COUNT = 1;
-    final int SEGMENT_COUNT = 5;
-
-    final int MIN_ROWS_PER_SEGMENT = 500;
-    final int MAX_ROWS_PER_SEGMENT = 1000;
-
-    final int OPERATIONS_PER_ITERATION = 10;
-    final int ITERATION_COUNT = 5;
-
-    final double UPLOAD_PROBABILITY = 0.8d;
-
-    final String[] segmentNames = new String[SEGMENT_COUNT];
-    final int[] segmentRowCounts = new int[SEGMENT_COUNT];
-
-    for (int i = 0; i < SEGMENT_COUNT; i++) {
-      segmentNames[i] = "segment_" + i;
-      segmentRowCounts[i] = 0;
-    }
-
-    for (int i = 0; i < ITERATION_COUNT; i++) {
-      // Create THREAD_COUNT threads
-      ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
-
-      // Submit OPERATIONS_PER_ITERATION uploads/deletes
-      for (int j = 0; j < OPERATIONS_PER_ITERATION; j++) {
-        executorService.submit(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              ThreadLocalRandom random = ThreadLocalRandom.current();
-
-              // Pick a random segment
-              int segmentIndex = random.nextInt(SEGMENT_COUNT);
-              String segmentName = segmentNames[segmentIndex];
-
-              // Pick a random operation
-              if (random.nextDouble() < UPLOAD_PROBABILITY) {
-                // Upload this segment
-                LOGGER.info("Will upload segment {}", segmentName);
-
-                synchronized (segmentName) {
-                  // Create a segment with a random number of rows
-                  int segmentRowCount = random.nextInt(MIN_ROWS_PER_SEGMENT, MAX_ROWS_PER_SEGMENT);
-                  LOGGER.info("Generating and uploading segment {} with {} rows", segmentName, segmentRowCount);
-                  generateAndUploadRandomSegment(segmentName, segmentRowCount);
-
-                  // Store the number of rows
-                  LOGGER.info("Uploaded segment {} with {} rows", segmentName, segmentRowCount);
-                  segmentRowCounts[segmentIndex] = segmentRowCount;
-                }
-              } else {
-                // Delete this segment
-                LOGGER.info("Will delete segment {}", segmentName);
-
-                synchronized (segmentName) {
-                  // Delete this segment
-                  LOGGER.info("Deleting segment {}", segmentName);
-                  String reply = sendDeleteRequest(_controllerRequestURLBuilder.
-                      forSegmentDelete("myresource", segmentName));
-                  LOGGER.info("Deletion returned {}", reply);
-
-                  // Set the number of rows to zero
-                  LOGGER.info("Deleted segment {}", segmentName);
-                  segmentRowCounts[segmentIndex] = 0;
-                }
-              }
-            } catch (Exception e) {
-              throw new RuntimeException(e);
-            }
-          }
-        });
-      }
-
-      // Await for all tasks to complete
-      executorService.shutdown();
-      executorService.awaitTermination(5L, TimeUnit.MINUTES);
-
-      // Count number of expected rows
-      int expectedRowCount = 0;
-      for (int segmentRowCount : segmentRowCounts) {
-        expectedRowCount += segmentRowCount;
-      }
-
-      // Wait for up to one minute for the row count to match the expected row count
-      LOGGER.info("Awaiting for the row count to match {}", expectedRowCount);
-      int pinotRowCount = (int) getCurrentCountStarResult();
-      long timeInOneMinute = System.currentTimeMillis() + 60 * 1000L;
-      while (System.currentTimeMillis() < timeInOneMinute && pinotRowCount != expectedRowCount) {
-        LOGGER.info("Row count is {}, expected {}, awaiting for row count to match", pinotRowCount, expectedRowCount);
-        Thread.sleep(5000L);
-
-        try {
-          pinotRowCount = (int) getCurrentCountStarResult();
-        } catch (Exception e) {
-          LOGGER.warn("Caught exception while sending query to Pinot, retrying", e);
-        }
-      }
-
-      // Compare row counts
-      Assert.assertEquals(pinotRowCount, expectedRowCount, "Expected and actual row counts don't match after waiting one minute");
-    }
   }
 
   @AfterClass
@@ -291,10 +165,15 @@ public class PinotSegmentUploadIntegrationTest extends BaseClusterIntegrationTes
     field.set(pinotSegmentUploadUtils, pinotFSFactory);
 
     ControllerConf controllerConf = new ControllerConf();
-    controllerConf.setPinotStorageDir(URLEncoder.encode(_controllerDataDir, "UTF-8"));
+    controllerConf.setPinotStorageDir(_segmentDir.getPath());
     Field field2 = pinotSegmentUploadUtils.getClass().getDeclaredField("_controllerConf");
     field2.setAccessible(true);
     field2.set(pinotSegmentUploadUtils, controllerConf);
+
+    PinotHelixResourceManager pinotHelixResourceManager = _controllerStarter.getHelixResourceManager();
+    Field field3 = pinotSegmentUploadUtils.getClass().getDeclaredField("_pinotHelixResourceManager");
+    field3.setAccessible(true);
+    field3.set(pinotSegmentUploadUtils, pinotHelixResourceManager);
 
     String[] unzippedSegments = _segmentDir.list();
     for (String segmentName : unzippedSegments) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/PinotSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/PinotSegmentUploadIntegrationTest.java
@@ -1,0 +1,292 @@
+package com.linkedin.pinot.integration.tests;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.controller.api.storage.PinotSegmentUploadUtils;
+import com.linkedin.pinot.controller.api.storage.SegmentUploaderConfig;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.util.TestUtils;
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class PinotSegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentUploadIntegrationTest.class);
+  private String _tableName;
+
+  @Nonnull
+  @Override
+  protected String getTableName() {
+    return _tableName;
+  }
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    // Start an empty Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+  }
+
+  @BeforeMethod
+  public void setupMethod(Object[] args) throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+    if (args == null || args.length == 0) {
+      return;
+    }
+    _tableName = (String) args[0];
+    SegmentVersion version = (SegmentVersion) args[1];
+    addOfflineTable(_tableName, version);
+  }
+
+  @AfterMethod
+  public void teardownMethod()
+      throws Exception {
+    if (_tableName != null) {
+      dropOfflineTable(_tableName);
+    }
+  }
+
+  protected void generateAndUploadRandomSegment(String segmentName, int rowCount) throws Exception {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    Schema schema = new Schema.Parser().parse(
+        new File(TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource("dummy.avsc"))));
+    GenericRecord record = new GenericData.Record(schema);
+    GenericDatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<GenericRecord>(schema);
+    DataFileWriter<GenericRecord> fileWriter = new DataFileWriter<GenericRecord>(datumWriter);
+    File avroFile = new File(_tempDir, segmentName + ".avro");
+    fileWriter.create(schema, avroFile);
+
+    for (int i = 0; i < rowCount; i++) {
+      record.put(0, random.nextInt());
+      fileWriter.append(record);
+    }
+
+    fileWriter.close();
+
+    int segmentIndex = Integer.parseInt(segmentName.split("_")[1]);
+
+    File segmentTarDir = new File(_tarDir, segmentName);
+    TestUtils.ensureDirectoriesExistAndEmpty(segmentTarDir);
+    ExecutorService executor = MoreExecutors.newDirectExecutorService();
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(Collections.singletonList(avroFile), segmentIndex,
+        new File(_segmentDir, segmentName), segmentTarDir, this._tableName, false, null, null, executor);
+    executor.shutdown();
+    executor.awaitTermination(1L, TimeUnit.MINUTES);
+
+    uploadSegmentsDirectly(segmentTarDir);
+
+    FileUtils.forceDelete(avroFile);
+    FileUtils.forceDelete(segmentTarDir);
+  }
+
+  @DataProvider(name = "configProvider")
+  public Object[][] configProvider() {
+    Object[][] configs = {
+        { "mytable", SegmentVersion.v1},
+        { "yourtable", SegmentVersion.v3}
+    };
+    return configs;
+  }
+
+  @Test(dataProvider = "configProvider")
+  public void testRefresh(String tableName, SegmentVersion version) throws Exception {
+    final int nAtttempts = 5;
+    final String segment6 = "segmentToBeRefreshed_6";
+    final int nRows1 = 69;
+    generateAndUploadRandomSegment(segment6, nRows1);
+    verifyNRows(0, nRows1);
+    final int nRows2 = 198;
+    LOGGER.info("Segment {} loaded with {} rows, refreshing with {}", segment6, nRows1, nRows2);
+    generateAndUploadRandomSegment(segment6, nRows2);
+    verifyNRows(nRows1, nRows2);
+    // Load another segment while keeping this one in place.
+    final String segment9 = "newSegment_9";
+    final int nRows3 = 102;
+    generateAndUploadRandomSegment(segment9, nRows3);
+    verifyNRows(nRows2, nRows2+nRows3);
+  }
+
+  // Verify that the number of rows is either the initial value or the final value but not something else.
+  private void verifyNRows(int currentNrows, int finalNrows) throws Exception {
+    int attempt = 0;
+    long sleepTime = 100;
+    long nRows;
+    while (attempt < 10) {
+      Thread.sleep(sleepTime);
+      try {
+        nRows = getCurrentCountStarResult();
+      } catch (Exception e) {
+        nRows = -1;
+      }
+      //nRows can either be the current value or the final value, not any other.
+      if (nRows == currentNrows || nRows == -1) {
+        sleepTime *= 2;
+        attempt++;
+      } else if (nRows == finalNrows) {
+        return;
+      } else {
+        Assert.fail("Found unexpected number of rows " + nRows);
+      }
+    }
+    Assert.fail("Failed to get from " + currentNrows + " to " + finalNrows);
+  }
+
+  @Test(enabled = false, dataProvider = "configProvider")
+  public void testUploadRefreshDelete(String tableName, SegmentVersion version) throws Exception {
+    final int THREAD_COUNT = 1;
+    final int SEGMENT_COUNT = 5;
+
+    final int MIN_ROWS_PER_SEGMENT = 500;
+    final int MAX_ROWS_PER_SEGMENT = 1000;
+
+    final int OPERATIONS_PER_ITERATION = 10;
+    final int ITERATION_COUNT = 5;
+
+    final double UPLOAD_PROBABILITY = 0.8d;
+
+    final String[] segmentNames = new String[SEGMENT_COUNT];
+    final int[] segmentRowCounts = new int[SEGMENT_COUNT];
+
+    for (int i = 0; i < SEGMENT_COUNT; i++) {
+      segmentNames[i] = "segment_" + i;
+      segmentRowCounts[i] = 0;
+    }
+
+    for (int i = 0; i < ITERATION_COUNT; i++) {
+      // Create THREAD_COUNT threads
+      ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+      // Submit OPERATIONS_PER_ITERATION uploads/deletes
+      for (int j = 0; j < OPERATIONS_PER_ITERATION; j++) {
+        executorService.submit(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              ThreadLocalRandom random = ThreadLocalRandom.current();
+
+              // Pick a random segment
+              int segmentIndex = random.nextInt(SEGMENT_COUNT);
+              String segmentName = segmentNames[segmentIndex];
+
+              // Pick a random operation
+              if (random.nextDouble() < UPLOAD_PROBABILITY) {
+                // Upload this segment
+                LOGGER.info("Will upload segment {}", segmentName);
+
+                synchronized (segmentName) {
+                  // Create a segment with a random number of rows
+                  int segmentRowCount = random.nextInt(MIN_ROWS_PER_SEGMENT, MAX_ROWS_PER_SEGMENT);
+                  LOGGER.info("Generating and uploading segment {} with {} rows", segmentName, segmentRowCount);
+                  generateAndUploadRandomSegment(segmentName, segmentRowCount);
+
+                  // Store the number of rows
+                  LOGGER.info("Uploaded segment {} with {} rows", segmentName, segmentRowCount);
+                  segmentRowCounts[segmentIndex] = segmentRowCount;
+                }
+              } else {
+                // Delete this segment
+                LOGGER.info("Will delete segment {}", segmentName);
+
+                synchronized (segmentName) {
+                  // Delete this segment
+                  LOGGER.info("Deleting segment {}", segmentName);
+                  String reply = sendDeleteRequest(_controllerRequestURLBuilder.
+                      forSegmentDelete("myresource", segmentName));
+                  LOGGER.info("Deletion returned {}", reply);
+
+                  // Set the number of rows to zero
+                  LOGGER.info("Deleted segment {}", segmentName);
+                  segmentRowCounts[segmentIndex] = 0;
+                }
+              }
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+        });
+      }
+
+      // Await for all tasks to complete
+      executorService.shutdown();
+      executorService.awaitTermination(5L, TimeUnit.MINUTES);
+
+      // Count number of expected rows
+      int expectedRowCount = 0;
+      for (int segmentRowCount : segmentRowCounts) {
+        expectedRowCount += segmentRowCount;
+      }
+
+      // Wait for up to one minute for the row count to match the expected row count
+      LOGGER.info("Awaiting for the row count to match {}", expectedRowCount);
+      int pinotRowCount = (int) getCurrentCountStarResult();
+      long timeInOneMinute = System.currentTimeMillis() + 60 * 1000L;
+      while (System.currentTimeMillis() < timeInOneMinute && pinotRowCount != expectedRowCount) {
+        LOGGER.info("Row count is {}, expected {}, awaiting for row count to match", pinotRowCount, expectedRowCount);
+        Thread.sleep(5000L);
+
+        try {
+          pinotRowCount = (int) getCurrentCountStarResult();
+        } catch (Exception e) {
+          LOGGER.warn("Caught exception while sending query to Pinot, retrying", e);
+        }
+      }
+
+      // Compare row counts
+      Assert.assertEquals(pinotRowCount, expectedRowCount, "Expected and actual row counts don't match after waiting one minute");
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+    FileUtils.deleteQuietly(_tempDir);
+  }
+
+  /**
+   * Upload all segments inside the given directory to the cluster.
+   *
+   * @param zippedSegmentDir Segment directory
+   */
+  protected void uploadSegmentsDirectly(@Nonnull File zippedSegmentDir) throws Exception {
+    String[] segmentNames = zippedSegmentDir.list();
+    Assert.assertNotNull(segmentNames);
+
+    PinotSegmentUploadUtils pinotSegmentUploadUtils = new PinotSegmentUploadUtils();
+
+    String[] unzippedSegments = _segmentDir.list();
+    for (String segmentName : unzippedSegments) {
+      File file = new File(_segmentDir, segmentName);
+      File refreshSegmentPath = file.listFiles()[0];
+      File segmentIndexFile = refreshSegmentPath.listFiles()[0];
+      SegmentMetadata segmentMetadata = new SegmentMetadataImpl(segmentIndexFile);
+      SegmentUploaderConfig segmentUploaderConfig = new SegmentUploaderConfig.Builder().setHeaders(null).setRequest(null).build();
+      pinotSegmentUploadUtils.push(segmentMetadata, file.toURI(), segmentUploaderConfig);
+    }
+  }
+}


### PR DESCRIPTION
Mirror of linkedin pinot#2794
* PinotFS is the Pinot wrapper around a filesystem operations. This PR contains a default local implementation.
* This PR also creates a new path for segment upload. Segment upload will be split into moving the data to the permanent directory and changing metadata in ZK so that clients can call metadataUpload directly.
* Segment versioning will be supported. We will store each new version of a segment in a directory with a new UUID.
* Note that the segment upload gets rid of the quota check/table since we will be versioning segments. 
